### PR TITLE
Fix bug with vanilla level costs and remove `v` prefix from release versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,14 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Set release version
+        run: |
+          TAG=${{ github.event.release.tag_name }}
+          echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT
+        id: version
+
       - name: Set project version
-        run: mvn -B versions:set -DnewVersion=${{ github.event.release.tag_name }} -DgenerateBackupPoms=false
+        run: mvn -B versions:set -DnewVersion=${{ steps.version.outputs.VERSION }} -DgenerateBackupPoms=false
 
       - name: Build and package Maven project
         run: mvn clean package
@@ -28,7 +34,7 @@ jobs:
       - name: Upload to release
         uses: JasonEtco/upload-to-release@master
         with:
-          args: target/EnchantBookPlus-${{ github.event.release.tag_name }}.jar application/java-archive
+          args: target/EnchantBookPlus-${{ steps.version.outputs.VERSION }}.jar application/java-archive
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -37,6 +43,6 @@ jobs:
         with:
           token: '${{ secrets.MODRINTH_TOKEN }}'
           project: '${{ github.event.repository.custom_properties.modrinth_id }}'
-          file: target/EnchantBookPlus-${{ github.event.release.tag_name }}.jar
+          file: target/EnchantBookPlus-${{ steps.version.outputs.VERSION }}.jar
           changelog: ${{ github.event.release.body }}
           loaders: paper

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This plugin allows you to combine enchantments, e.g. Efficiency V + Efficiency V
 You can configure which enchantments can be combined above the Vanilla Minecraft levels. You can set the max level for each enchantment, and add XP cost in levels.
 
 > [!IMPORTANT]
-> This plugin requires [AnvilUnlocker](https://github.com/Jikoo/AnvilUnlocker/releases/latest) for anvil costs above 40 lvl.
+> You need [AnvilUnlocker](https://github.com/Jikoo/AnvilUnlocker/releases/latest) for anvil costs above 40 lvl to
+> disable the "Too Expensive!" message.
 
 ## Permissions
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 Combine enchantment books to achieve levels above vanilla
 
 ## How it works
-This plugin allows you to combine enchantments, e.g. Efficiency V + Efficiency V = Efficiency VI. This is done by using an anvil.
+This plugin allows you to combine enchantments, e.g. Efficiency V + Efficiency V = Efficiency VI.
+This is done by using an anvil.
 
-You can configure which enchantments can be combined above the Vanilla Minecraft levels. You can set the max level for each enchantment, and add XP cost in levels.
+You can configure which enchantments can be combined above the Vanilla Minecraft levels.
+You can set the max level for each enchantment, and add XP cost in levels.
 
 > [!IMPORTANT]
 > You need [AnvilUnlocker](https://github.com/Jikoo/AnvilUnlocker/releases/latest) for anvil costs above 40 lvl to
@@ -30,7 +32,10 @@ You can configure which enchantments can be combined above the Vanilla Minecraft
 | `enchantbookplus.reload`                | Reload plugin config using `/enchantbookplus reload`                                   |
 
 ## Reporting issues
-Fixing bugs is the utmost priority for this project. If you find any issue, check the [GitHub Issue Tracker](https://github.com/cloudnode-pro/EnchantBookPlus/issues) to see if it has already been reported. If not, create a new issue.
+Fixing bugs is the utmost priority for this project.
+If you find any issue,
+check the [GitHub Issue Tracker](https://github.com/cloudnode-pro/EnchantBookPlus/issues)
+to see if it has already been reported. If not, create a new issue.
 
 When creating a new issue, include as many relevant details as possible, e.g.:
 
@@ -53,4 +58,5 @@ Pull requests require approval and changes may be requested before merging to th
 Contributions of any kind are most welcome and are given full credit.
 
 ### License
-This is libre software, meaning that it is forever free and open source, licensed under the GNU General Public License version 3. You can read the [full license](https://github.com/cloudnode-pro/EnchantBookPlus/blob/main/LICENSE). 
+This is libre software, meaning that it is forever free and open source, licensed under the GNU General Public License
+version 3. You can read the [full license](https://github.com/cloudnode-pro/EnchantBookPlus/blob/main/LICENSE). 

--- a/src/main/java/pro/cloudnode/smp/enchantbookplus/event/PrepareAnvil.java
+++ b/src/main/java/pro/cloudnode/smp/enchantbookplus/event/PrepareAnvil.java
@@ -50,7 +50,7 @@ public final class PrepareAnvil implements Listener {
                 else finalLevel = upgradeLevel;
             }
             else finalLevel = upgradeLevel;
-            if (finalLevel < enchantment.getMaxLevel()) continue;
+            if (finalLevel <= enchantment.getMaxLevel()) continue;
             if (configEnchantment.get().getMaxLevel().isPresent() && finalLevel > configEnchantment.get().getMaxLevel().get()) continue;
             if (finalLevel > upgradeLevel) cost += configEnchantment.get().getMultiplyCostByLevel() ? configEnchantment.get().getCost() * (finalLevel - enchantment.getMaxLevel()) : configEnchantment.get().getCost();
             upgrades.put(enchantment, finalLevel);


### PR DESCRIPTION
- Cost is not added anymore if the level is within the vanilla limits
- The release workflow has been updated to strip the `v` prefix of tags when setting the release version
- The readme received minor improvements