### PR TITLE
Add allow-custom-enchantments config option and null safety for missing enchantments

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -35,4 +35,5 @@ jobs:
 
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Submit Dependency Snapshot
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: advanced-security/maven-dependency-submission-action@v5

--- a/src/main/java/pro/cloudnode/smp/enchantbookplus/ConfigEnchantmentEntry.java
+++ b/src/main/java/pro/cloudnode/smp/enchantbookplus/ConfigEnchantmentEntry.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalInt;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 @NullMarked
@@ -39,6 +40,21 @@ public class ConfigEnchantmentEntry {
      * Multiply cost by level.
      */
     protected final boolean multiplyCostByLevel;
+
+    /**
+     * Whether to allow custom enchantments from other plugins.
+     * Set this from the main plugin class.
+     */
+    private static boolean allowCustomEnchantments = true;
+
+    /**
+     * Set whether custom enchantments are allowed.
+     *
+     * @param allow true to allow custom enchantments, false to only use vanilla enchantments
+     */
+    public static void setAllowCustomEnchantments(final boolean allow) {
+        allowCustomEnchantments = allow;
+    }
 
     /**
      * @param name Name of the enchantment.
@@ -194,8 +210,13 @@ public class ConfigEnchantmentEntry {
             return OptionalInt.empty();
         }
 
+        final Enchantment enchantment = getEnchantment();
+        if (enchantment == null) {
+            return OptionalInt.empty();
+        }
+
         if (maxLevelRelative) {
-            return OptionalInt.of(getEnchantment().getMaxLevel() + maxLevel);
+            return OptionalInt.of(enchantment.getMaxLevel() + maxLevel);
         }
 
         return OptionalInt.of(maxLevel);
@@ -218,8 +239,12 @@ public class ConfigEnchantmentEntry {
     /**
      * Get enchantment
      */
-    public final Enchantment getEnchantment() {
-        return Objects.requireNonNull(Registry.ENCHANTMENT.get(NamespacedKey.minecraft(name)));
+    public final @Nullable Enchantment getEnchantment() {
+        final Enchantment enchantment = Registry.ENCHANTMENT.get(NamespacedKey.minecraft(name));
+        if (enchantment == null) {
+            java.util.logging.Logger.getLogger("EnchantBookPlus").warning("Enchantment '" + name + "' not found in registry");
+        }
+        return enchantment;
     }
 
     /**
@@ -250,7 +275,18 @@ public class ConfigEnchantmentEntry {
             );
         }
 
-        public ConfigEnchantmentEntry enchant(final Enchantment enchantment) {
+        /**
+         * Create a ConfigEnchantmentEntry for a specific enchantment.
+         * Returns null if the enchantment is custom and custom enchantments are disabled.
+         *
+         * @param enchantment The enchantment to create an entry for
+         * @return A new ConfigEnchantmentEntry, or null if skipped
+         */
+        public @Nullable ConfigEnchantmentEntry enchant(final Enchantment enchantment) {
+            // Skip custom enchantments if they are not allowed
+            if (!allowCustomEnchantments && !enchantment.getKey().getNamespace().equals(NamespacedKey.MINECRAFT)) {
+                return null;
+            }
             return new ConfigEnchantmentEntry(
                     enchantment.getKey().getKey(),
                     this.maxLevel,

--- a/src/main/java/pro/cloudnode/smp/enchantbookplus/EnchantBookPlus.java
+++ b/src/main/java/pro/cloudnode/smp/enchantbookplus/EnchantBookPlus.java
@@ -55,7 +55,19 @@ public final class EnchantBookPlus extends JavaPlugin {
                 .filter(c -> c.isEnchantment(enchantment))
                 .findFirst();
 
-        return entry.isEmpty() ? getAllConfigEnchantment().map(a -> a.enchant(enchantment)) : entry;
+        if (entry.isPresent()) {
+            return entry;
+        }
+
+        // If "ALL" entry exists, create a specific entry for this enchantment
+        final Optional<ConfigEnchantmentEntry.AllConfigEnchantmentEntry> allEntry = getAllConfigEnchantment();
+        if (allEntry.isPresent()) {
+            final ConfigEnchantmentEntry specificEntry = allEntry.get().enchant(enchantment);
+            // If the enchantment was skipped (null), return empty
+            return Optional.ofNullable(specificEntry);
+        }
+
+        return Optional.empty();
     }
 
     /**
@@ -63,6 +75,10 @@ public final class EnchantBookPlus extends JavaPlugin {
      */
     void reload() {
         reloadConfig();
+
+        // Load the allow-custom-enchantments setting from config
+        final boolean allowCustom = getConfig().getBoolean("allow-custom-enchantments", true);
+        ConfigEnchantmentEntry.setAllowCustomEnchantments(allowCustom);
 
         final List<ConfigEnchantmentEntry> enchants;
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,8 @@
+# Enable or disable processing of custom enchantments from other plugins (e.g., ExcellentEnchants)
+# If disabled, only vanilla Minecraft enchantments will be affected by the "ALL" rule
+# Set to true to allow custom enchantments, false to only use vanilla enchantments
+allow-custom-enchantments: false
+
 # List of enchantments for which to enable upgrading above the vanilla max levels using an anvil.
 enchantments:
     # Enchantment name (same as in the /enchant command).


### PR DESCRIPTION
PR adds a configurable toggle for custom enchantment support and improves null safety when enchantments are not found in the registry.

1 Added allow-custom-enchantments config option
When false (default), the "ALL" rule only applies to vanilla Minecraft enchantments
When true, the "ALL" rule applies to all enchantments including custom ones
Config option is generated automatically on first run

2 Added null safety to getEnchantment() method
Returns null instead of throwing NullPointerException when enchantment not found
* Logs a warning to console instead of crashing *

3 Added null check to getMaxLevel() method
Returns OptionalInt.empty() when enchantment is null
Prevents crashes when custom enchantments are missing

4 Modified AllConfigEnchantmentEntry.enchant() method
Skips custom enchantments when allow-custom-enchantments is false
Returns null for skipped enchantments

5 Modified getConfigEnchantment() in main class
Filters out null entries from the "ALL" expansion
Uses Optional.ofNullable() to handle skipped enchantments